### PR TITLE
chore: add github actions ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  backend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-java@v4
+        with:
+          java-version: "17"
+          distribution: "temurin"
+      - name: Run backend tests
+        run: cd backend && mvn test
+  frontend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "20"
+      - name: Install and build frontend
+        run: cd frontend && npm ci && npm run lint && npm run build


### PR DESCRIPTION
## Summary

Adds a GitHub Actions CI workflow that runs on every push and PR to `main`.

## Changes
- `.github/workflows/ci.yml` — CI workflow with two jobs:
  - **backend** — sets up Java 17 and runs `mvn test`
  - **frontend** — sets up Node.js and runs `npm ci && npm run lint && npm run build`

## Why
Ensures PRs don't break the build before merging.

## How to test
1. Open a PR to `main`
2. Verify both `backend` and `frontend` jobs run automatically in the Actions tab