### PR TITLE
fix: remove unnecessary React imports in Meals.jsx and Workouts.jsx

### DIFF
--- a/frontend/src/pages/Meals.jsx
+++ b/frontend/src/pages/Meals.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { useData } from "../context/useData";
 
 export default function Meals() {

--- a/frontend/src/pages/Workouts.jsx
+++ b/frontend/src/pages/Workouts.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { useData } from "../context/useData";
 
 export default function Workouts() {


### PR DESCRIPTION
## Summary

Fixes #20

Both `Meals.jsx` and `Workouts.jsx` were importing `React` unnecessarily alongside `useState`. Since this project uses React with the new JSX transform via Vite, the `React` default import is not needed and triggers an ESLint `no-unused-vars` warning.

## Changes

- `frontend/src/pages/Meals.jsx`: Changed `import React, { useState } from "react"` → `import { useState } from "react"`
- - `frontend/src/pages/Workouts.jsx`: Changed `import React, { useState } from "react"` → `import { useState } from "react"`
## Testing

No functional changes — this is a cleanup fix. The components behave identically, and the ESLint `no-unused-vars` warning is resolved.